### PR TITLE
[FIX] tx status inconsistency in history

### DIFF
--- a/arkive-cli/src/commands/transaction.rs
+++ b/arkive-cli/src/commands/transaction.rs
@@ -139,7 +139,6 @@ pub async fn handle_transaction_command(
 
         TransactionCommands::History { wallet, limit } => {
             let wallet = manager.load_wallet(&wallet).await?;
-
             println!("Transaction history for wallet '{}':", wallet.name());
 
             let transactions = wallet.transaction_history().await?;
@@ -151,7 +150,7 @@ pub async fn handle_transaction_command(
 
             let mut table = Table::new();
             table.load_preset(UTF8_FULL);
-            table.set_header(vec!["Date", "Type", "Amount", "Status", "TXID"]);
+            table.set_header(vec!["Date", "Type", "Amount", "Status", "TXID", "Round"]);
 
             for tx in transactions.iter().take(limit) {
                 let amount_str = if tx.amount >= 0 {
@@ -160,12 +159,19 @@ pub async fn handle_transaction_command(
                     format!("{} sats", tx.amount)
                 };
 
+                let round_display = tx
+                    .ark_round_id
+                    .as_ref()
+                    .map(|id| id.replace("round_", ""))
+                    .unwrap_or_else(|| "-".to_string());
+
                 table.add_row(vec![
                     &tx.timestamp.format("%Y-%m-%d %H:%M").to_string(),
                     &format!("{:?}", tx.tx_type),
                     &amount_str,
                     &format!("{:?}", tx.status),
-                    &tx.txid[..16], // truncated for display
+                    &tx.txid[..16],
+                    &round_display,
                 ]);
             }
 

--- a/arkive-core/src/types.rs
+++ b/arkive-core/src/types.rs
@@ -31,6 +31,8 @@ pub struct Transaction {
     pub tx_type: TransactionType,
     pub status: TransactionStatus,
     pub fee: Option<Amount>,
+    pub source: TransactionSource,
+    pub ark_round_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +48,7 @@ pub enum TransactionStatus {
     Pending,
     Confirmed,
     Failed,
+    Spent,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,4 +79,11 @@ pub enum VtxoStatus {
     Confirmed,
     Spent,
     Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TransactionSource {
+    Blockchain,
+    ArkServer,
+    LocalRound,
 }

--- a/arkive-core/src/wallet/instance.rs
+++ b/arkive-core/src/wallet/instance.rs
@@ -4,6 +4,7 @@ use crate::error::{ArkiveError, Result};
 use crate::storage::Storage;
 use crate::types::{Address, AddressType, Balance, Transaction, VtxoInfo};
 use crate::wallet::WalletConfig;
+
 use ark_core::ArkAddress;
 use bitcoin::key::Keypair;
 use bitcoin::{Amount, Network};
@@ -28,7 +29,9 @@ impl ArkWallet {
         config: WalletConfig,
         storage: Arc<Storage>,
     ) -> Result<Self> {
-        let bitcoin_service = BitcoinService::new(keypair, config.clone()).await?;
+        let bitcoin_service =
+            BitcoinService::new(keypair, config.clone(), storage.clone(), id.clone()).await?;
+
         let ark_service =
             ArkService::new(keypair, config.clone(), storage.clone(), id.clone()).await?;
 


### PR DESCRIPTION
## Overview:
This PR closes #15 
Tx history was displaying inconsistent status for boarding outputs, showing them as "Confirmed" after successful round participation, then reverting to "Pending" on subsequent syncs. This created a confusing UX where tx status would flicker between states.

The issue arise from tx state management problems in the sync process:
- `force_sync_with_server` method was using `INSERT OR REPLACE` which overwrote existing tx with default "Pending" status even if they had been previously marked as "Spent" after round participation.
- No mechanism existed to preserve tx status during sync operations causing confirmed boarding outputs to revert to pending state.
- Tx history came from multiple sources (local detection, server sync, round participation) without proper coordination, leading to conflicting status updates.

## Solution
1. Introduced a dedicated TransactionManager that handles all transaction state operations:
     - `record_transaction_if_new` only records tx that don't exist preserving existing status
     - `update_transaction_status` for status updates with validation
     - `mark_boarding_outputs_spent` to tracks boarding outputs consumed in rounds
2. Improved tx table with proper state tracking
```sql
ALTER TABLE transactions ADD COLUMN source TEXT NOT NULL DEFAULT 'Blockchain';
ALTER TABLE transactions ADD COLUMN last_updated INTEGER NOT NULL;
ALTER TABLE transactions ADD COLUMN ark_round_id TEXT;
```
3. Unified tx management b/w Ark service, Blockhain service and state transitions
4. Tx source tracking to distinguish between ark server, blockchain and local round