### PR TITLE
fix: batch sattlement when only VTXOs are present and ark Tx for pending VTXOs

### DIFF
--- a/arkive-cli/src/commands/transaction.rs
+++ b/arkive-cli/src/commands/transaction.rs
@@ -106,11 +106,12 @@ pub async fn handle_transaction_command(
             let amount = Amount::from_sat(amount);
 
             // Check Ark balance
-            let (confirmed, _pending) = wallet.ark_balance().await?;
-            if confirmed < amount {
+            let (confirmed, pending) = wallet.ark_balance().await?;
+            let total_bal = confirmed + pending;
+            if total_bal < amount {
                 return Err(ArkiveError::InsufficientFunds {
                     need: amount.to_sat(),
-                    available: confirmed.to_sat(),
+                    available: total_bal.to_sat(),
                 });
             }
 

--- a/arkive-core/src/ark/mod.rs
+++ b/arkive-core/src/ark/mod.rs
@@ -488,7 +488,11 @@ impl ArkService {
         let now = Utc::now();
         let spendable: Vec<VtxoState> = all_vtxos
             .into_iter()
-            .filter(|vtxo| matches!(vtxo.status, VtxoStatus::Confirmed) && vtxo.expiry > now)
+            .filter(|vtxo| {
+                (matches!(vtxo.status, VtxoStatus::Confirmed) || 
+                 matches!(vtxo.status, VtxoStatus::Pending)) && 
+                vtxo.expiry > now
+            })
             .collect();
 
         Ok(spendable)

--- a/arkive-core/src/ark/mod.rs
+++ b/arkive-core/src/ark/mod.rs
@@ -489,9 +489,9 @@ impl ArkService {
         let spendable: Vec<VtxoState> = all_vtxos
             .into_iter()
             .filter(|vtxo| {
-                (matches!(vtxo.status, VtxoStatus::Confirmed) || 
-                 matches!(vtxo.status, VtxoStatus::Pending)) && 
-                vtxo.expiry > now
+                (matches!(vtxo.status, VtxoStatus::Confirmed)
+                    || matches!(vtxo.status, VtxoStatus::Pending))
+                    && vtxo.expiry > now
             })
             .collect();
 

--- a/arkive-core/src/wallet/instance.rs
+++ b/arkive-core/src/wallet/instance.rs
@@ -122,11 +122,12 @@ impl ArkWallet {
             .map_err(|e| ArkiveError::InvalidAddress(format!("Invalid Ark address: {}", e)))?;
 
         // Check balance before sending
-        let (confirmed, _) = self.ark_service.get_balance().await?;
-        if confirmed < amount {
+        let (confirmed, pending) = self.ark_service.get_balance().await?;
+        let total_bal = confirmed + pending;
+        if total_bal < amount {
             return Err(ArkiveError::InsufficientFunds {
                 need: amount.to_sat(),
-                available: confirmed.to_sat(),
+                available: total_bal.to_sat(),
             });
         }
 


### PR DESCRIPTION
## Overview:
The arkive-core implementation had a critical issue where pending VTXOs could not participate in rounds until there are boarding inputs to participate in rounds with, breaking the fundamental Ark protocol flow. This pr Closes #8 

## Issue:
`get_spendable_vtxos` method was filtering out VtxoStatus::Pending VTXOs, but pending VTXOs must participate in rounds to become confirmed.